### PR TITLE
feat: automatically apply flows.sql to directus

### DIFF
--- a/roles/directus/tasks/main.yaml
+++ b/roles/directus/tasks/main.yaml
@@ -46,6 +46,23 @@
     container: "{{ container_name }}"
     command: npx directus schema apply /snapshot.yaml -y
 
+- name: Download flows
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/clicepfl/directus-config/main/flows.sql
+    dest: "{{ role_path }}/files/snapshot.yaml"
+    mode: 777
+
+- name: Copy flows into container
+  community.docker.docker_container_copy_into:
+    container: "{{ container_name }}"
+    container_path: /flows.sql
+    path: "{{ role_path }}/files/flows.sql"
+
+- name: Apply flows script
+  community.docker.docker_container_exec:
+    container: "{{ container_name }}"
+    command: psql -U directus_user directus_data -f /flows.sql
+
 - name: Restart container
   community.docker.docker_container:
     name: "{{ container_name }}"


### PR DESCRIPTION
When deploying directus, fetches the `flows.sql` file on the directus-config repo and applies it to the database.

This PR piggy backs on https://github.com/clicepfl/directus-config/pull/10