### PR TITLE
fix: ignore push events to non-default branches

### DIFF
--- a/roles/webhook/files/src/error.rs
+++ b/roles/webhook/files/src/error.rs
@@ -4,6 +4,7 @@ use actix_web::{http::StatusCode, ResponseError};
 
 #[derive(Debug)]
 pub enum Error {
+    BadRequest,
     InvalidSignature,
     InvalidServiceList,
     ForbiddenEvent,
@@ -13,6 +14,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Error::BadRequest => f.write_str("Bad request"),
             Error::InvalidSignature => f.write_str("Invalid Signature"),
             Error::InvalidServiceList => f.write_str("Invalid service list"),
             Error::ForbiddenEvent => f.write_str("Event is not allowed"),
@@ -24,6 +26,7 @@ impl Display for Error {
 impl ResponseError for Error {
     fn status_code(&self) -> StatusCode {
         match self {
+            Error::BadRequest => StatusCode::BAD_REQUEST,
             Error::InvalidSignature => StatusCode::FORBIDDEN,
             Error::InvalidServiceList => StatusCode::BAD_REQUEST,
             Error::ForbiddenEvent => StatusCode::BAD_REQUEST,

--- a/roles/webhook/files/src/github/event.rs
+++ b/roles/webhook/files/src/github/event.rs
@@ -1,8 +1,13 @@
+use actix_web::http::header::HeaderMap;
 use serde::Deserialize;
+
+use crate::error::Error;
 
 #[derive(Deserialize, Debug)]
 pub struct Package {
     pub name: String,
+    pub updated_at: Option<String>,
+    pub html_url: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -13,12 +18,34 @@ pub enum Action {
 
 #[derive(Deserialize, Debug)]
 pub struct Repository {
+    pub html_url: String,
     pub default_branch: String,
 }
 
 #[derive(Deserialize, Debug)]
+pub struct Commit {}
+
+#[derive(Deserialize, Debug)]
 pub struct Push {
+    pub after: String,
     pub repository: Repository,
+    pub commits: Vec<Commit>,
     #[serde(rename = "ref")]
     pub r#ref: String,
+}
+
+pub const HEADER_EVENT: &str = "X-GitHub-Event";
+pub const HEADER_DELIVERY_ID: &str = "X-GitHub-Delivery";
+
+pub enum Payload {
+    Action(Action),
+    Push(Push),
+}
+
+pub fn parse_payload(headers: &HeaderMap, payload: &[u8]) -> Result<Payload, Error> {
+    match headers.get(HEADER_EVENT).and_then(|h| h.to_str().ok()) {
+        Some("action") => Ok(Payload::Action(serde_json::from_slice(payload)?)),
+        Some("push") => Ok(Payload::Push(serde_json::from_slice(payload)?)),
+        _ => Err(Error::ForbiddenEvent),
+    }
 }

--- a/roles/webhook/files/src/github/issues.rs
+++ b/roles/webhook/files/src/github/issues.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct PostIssueBody {
+    pub title: String,
+    pub body: String,
+    pub assignees: Vec<String>,
+}
+#[derive(Serialize, Deserialize)]
+pub struct EmptyBody {}

--- a/roles/webhook/files/src/main.rs
+++ b/roles/webhook/files/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Mutex, time::SystemTime};
+use std::sync::Mutex;
 
 use actix_web::{web, App, HttpServer};
 use config::config;
@@ -17,7 +17,6 @@ mod validation;
 #[derive(Debug, Default)]
 pub struct WebhookState {
     pub processed_deliveries: Vec<String>,
-    pub processed_packages: HashMap<String, SystemTime>,
 }
 pub type State = Mutex<WebhookState>;
 

--- a/roles/webhook/files/src/routes.rs
+++ b/roles/webhook/files/src/routes.rs
@@ -42,12 +42,15 @@ pub async fn all(
         tracing::info!("Full restart complete");
 
         let log = stop_capture();
-        let payload = String::from_utf8_lossy(&payload).to_string();
-
         if failed {
-            open_issue(log, vec![], payload).await;
+            open_issue(log, vec![], req.headers(), &payload).await;
         } else {
-            close_issues(config().services.keys().cloned().collect(), payload).await;
+            close_issues(
+                config().services.keys().cloned().collect(),
+                req.headers(),
+                &payload,
+            )
+            .await;
         }
     });
 
@@ -83,12 +86,10 @@ pub async fn targeted(
         };
 
         let log = stop_capture();
-        let payload = String::from_utf8_lossy(&payload).to_string();
-
         if failed {
-            open_issue(log, vec![service.to_string()], payload).await;
+            open_issue(log, vec![service.to_string()], req.headers(), &payload).await;
         } else {
-            close_issues(vec![service.to_string()], payload).await;
+            close_issues(vec![service.to_string()], req.headers(), &payload).await;
         }
     });
 


### PR DESCRIPTION
Ignores push events which do not target the repository's default branch. Furthermore, this PR improves redelivery identification by using the delivery unique identifier. I also refactored the way the payload is parsed to correctly take into account the `X-Github-Event` header.
