### PR TITLE
refactor: use reqwest & add docs

### DIFF
--- a/roles/webhook/files/Cargo.toml
+++ b/roles/webhook/files/Cargo.toml
@@ -11,6 +11,7 @@ ascii = "1.1.0"
 hex = "0.4.3"
 hmac = "0.12.1"
 regex = "1.10.6"
+reqwest = "0.12.24"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 sha2 = "0.10.8"

--- a/roles/webhook/files/src/error.rs
+++ b/roles/webhook/files/src/error.rs
@@ -6,7 +6,7 @@ use actix_web::{http::StatusCode, ResponseError};
 pub enum Error {
     BadRequest,
     InvalidSignature,
-    InvalidServiceList,
+    InvalidService,
     ForbiddenEvent,
     Actix(actix_web::Error),
 }
@@ -16,7 +16,7 @@ impl Display for Error {
         match self {
             Error::BadRequest => f.write_str("Bad request"),
             Error::InvalidSignature => f.write_str("Invalid Signature"),
-            Error::InvalidServiceList => f.write_str("Invalid service list"),
+            Error::InvalidService => f.write_str("Invalid service"),
             Error::ForbiddenEvent => f.write_str("Event is not allowed"),
             Error::Actix(e) => e.fmt(f),
         }
@@ -28,7 +28,7 @@ impl ResponseError for Error {
         match self {
             Error::BadRequest => StatusCode::BAD_REQUEST,
             Error::InvalidSignature => StatusCode::FORBIDDEN,
-            Error::InvalidServiceList => StatusCode::BAD_REQUEST,
+            Error::InvalidService => StatusCode::BAD_REQUEST,
             Error::ForbiddenEvent => StatusCode::BAD_REQUEST,
             Error::Actix(e) => e.as_response_error().status_code(),
         }

--- a/roles/webhook/files/src/github/issues.rs
+++ b/roles/webhook/files/src/github/issues.rs
@@ -8,3 +8,19 @@ pub struct PostIssueBody {
 }
 #[derive(Serialize, Deserialize)]
 pub struct EmptyBody {}
+
+#[derive(Deserialize, Clone)]
+pub struct OpenIssueBody {
+    pub number: u32,
+    pub title: String,
+}
+
+#[derive(Serialize)]
+pub struct IssueCommentBody {
+    pub body: String,
+}
+
+#[derive(Serialize)]
+pub struct UpdateIssueBody {
+    pub state: String,
+}

--- a/roles/webhook/files/src/log.rs
+++ b/roles/webhook/files/src/log.rs
@@ -1,3 +1,5 @@
+//! Custom logger, allowing to capture parts of the log output through the [`start_capture`] and [`stop_capture`] commands.
+
 use std::{
     io::{self, Write},
     sync::Mutex,

--- a/roles/webhook/files/src/restart.rs
+++ b/roles/webhook/files/src/restart.rs
@@ -1,7 +1,13 @@
+//! Functions to redeploy a service.
+
 use crate::config::Service;
 use std::process::Command;
 use tracing::{span, Level};
 
+/// Attempts to run a shell command, logging its output in case of failure.
+///
+/// - `command`: The command to run. This function does nothing if this value is `None`.
+/// - `service`: The value to pass to the command through the `SERVICE` environment variable.
 fn try_run(command: Option<&String>, service: &str) -> bool {
     let Some(command) = command else {
         tracing::debug!("Command is empty, skipping");
@@ -30,6 +36,11 @@ fn try_run(command: Option<&String>, service: &str) -> bool {
     }
 }
 
+/// Restarts the given service.
+///
+/// - `name`: Name of the service to restart
+/// - `service`: Specific deployment configuration for that service.
+/// - `default`: Default deployment configuration.
 pub fn restart(name: &str, service: &Service, default: &Service) -> bool {
     let _enter = span!(Level::INFO, "service", name).entered();
 


### PR DESCRIPTION
This PR mainly adds documentation to the webhook code. It also adds some slight improvement to the codebase:

- Use the [`reqwest`](https://crates.io/reqwest) crate to call the GitHub API instead of `curl`.
- Move all issue-related data types to `crate::github::issues`.
- Update the validation and issue functions such that `/<service>` is not considered a comma-separated list anymore.

