### PR TITLE
fix: http redirecting to port 4000 upon request

### DIFF
--- a/roles/caddy/files/Caddyfile
+++ b/roles/caddy/files/Caddyfile
@@ -92,6 +92,11 @@ https://clic.epfl.ch {
 	redir /shelf https://clic.epfl.ch:7004
 }
 
+# Temporary fix for http redirecting to wrong port when ambiguous -> see https://github.com/caddyserver/caddy/issues/4529
+clic.epfl.ch:80 {
+  redir https://clic.epfl.ch
+}
+
 # Github Webhooks
 https://clic.epfl.ch:4000 {
 	reverse_proxy http://0.0.0.0:4001


### PR DESCRIPTION
See my comment on https://github.com/caddyserver/caddy/issues/4529

## TLDR: 

Running `curl -iL clic.epfl.ch` redirects to the wrong port (port 4000)

This is also achievable by visiting `http://clic.epfl.ch`

This fixes the Caddyfile to redirect http content arriving on port 80 to https